### PR TITLE
Remove redundant commitlint rule hint from AI prompt

### DIFF
--- a/lua/aicommits/prompts.lua
+++ b/lua/aicommits/prompts.lua
@@ -37,10 +37,6 @@ function M.build_system_prompt(max_length, commitlint_config)
   if commitlint_config then
     table.insert(parts, "IMPORTANT: The following commitlint rules are STRICTLY ENFORCED in this repository.")
     table.insert(parts, "You MUST follow every rule exactly. Violating any rule is not acceptable.")
-    table.insert(
-      parts,
-      "Pay special attention to `subject-case` (never sentence-case or start-case) and `type-enum` (only listed types allowed)."
-    )
     table.insert(parts, commitlint_config)
     table.insert(parts, "Double-check your message against every rule above before responding.")
   end


### PR DESCRIPTION
## Summary

The system prompt included a hardcoded reminder to "pay special attention to `subject-case` and `type-enum`" rules. Since the full commitlint config is already appended to the prompt, this line was redundant and added unnecessary noise.

## Key Changes

- Remove 4 lines from the system prompt that duplicated guidance already covered by the commitlint config inclusion

🤖 Generated with [Claude Code](https://claude.com/claude-code)