### PR TITLE
Tighten commit prompts and fix Vertex global endpoint

### DIFF
--- a/lua/aicommits/prompts.lua
+++ b/lua/aicommits/prompts.lua
@@ -24,10 +24,16 @@ function M.build_system_prompt(max_length, commitlint_config)
   }
 
   local parts = {
-    "Generate a concise git commit message written in present tense for the following code diff with the given specifications below:",
+    "Generate a single-sentence git commit message in present tense for the following diff.",
+    "The message MUST be no more than 12 words. Be extremely brief.",
     "Message language: en",
     string.format("Commit message must be a maximum of %d characters.", max_length),
     "Exclude anything unnecessary such as translation. Your entire response will be passed directly into git commit.",
+    "Strictly follow Conventional Commits 1.0.0 spec. The message MUST pass commitlint with @commitlint/config-conventional rules:",
+    "- Subject line: lowercase, no period at end, imperative mood, no trailing whitespace.",
+    "- Type MUST be one of the allowed types below. Scope is optional and lowercase.",
+    "- Header (type + scope + subject) must not exceed " .. tostring(max_length) .. " characters total.",
+    "- Do NOT include a body or footer. Output only the single header line.",
     "Choose a type from the type-to-description JSON below that best describes the git diff:",
     vim.json.encode(commit_types),
     "The output response must be in format:",

--- a/lua/aicommits/providers/vertex.lua
+++ b/lua/aicommits/providers/vertex.lua
@@ -110,9 +110,7 @@ function M:generate_commit_message(diff, config, callback)
     local max_tokens = config.max_tokens or 200
 
     -- Build Vertex AI endpoint (global has no region prefix in hostname)
-    local host = location == "global"
-      and "aiplatform.googleapis.com"
-      or location .. "-aiplatform.googleapis.com"
+    local host = location == "global" and "aiplatform.googleapis.com" or location .. "-aiplatform.googleapis.com"
     local endpoint = string.format(
       "https://%s/v1/projects/%s/locations/%s/publishers/google/models/%s:generateContent",
       host,

--- a/lua/aicommits/providers/vertex.lua
+++ b/lua/aicommits/providers/vertex.lua
@@ -109,10 +109,13 @@ function M:generate_commit_message(diff, config, callback)
     local temperature = config.temperature or 0.7
     local max_tokens = config.max_tokens or 200
 
-    -- Build Vertex AI endpoint
+    -- Build Vertex AI endpoint (global has no region prefix in hostname)
+    local host = location == "global"
+      and "aiplatform.googleapis.com"
+      or location .. "-aiplatform.googleapis.com"
     local endpoint = string.format(
-      "https://%s-aiplatform.googleapis.com/v1/projects/%s/locations/%s/publishers/google/models/%s:generateContent",
-      location,
+      "https://%s/v1/projects/%s/locations/%s/publishers/google/models/%s:generateContent",
+      host,
       project,
       location,
       model


### PR DESCRIPTION
## Summary

Improves AI-generated commit messages by enforcing brevity and Conventional Commits 1.0.0 compliance directly in the prompt, and fixes the Vertex AI provider to correctly resolve the endpoint host when `location = "global"`.

## Key Changes

- Prompt now requires a single-sentence, ≤12-word, lowercase imperative subject with no body/footer
- Explicit commitlint-aligned rules baked into the system prompt (type-enum, header length, subject-case)
- Removed redundant `subject-case`/`type-enum` advice now covered by the stricter rules
- Vertex provider uses `aiplatform.googleapis.com` for `global` and `<region>-aiplatform.googleapis.com` otherwise

## Test plan

- [ ] Generate a commit on a repo with commitlint configured and verify rules pass
- [ ] Run Vertex provider with `location = "global"` and confirm requests succeed
- [ ] Run Vertex provider with a regional location (e.g. `us-central1`) and confirm requests still succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)